### PR TITLE
Less verbose default output plus summary line with template count

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/remcohaszing/grunt-angular-templatecache",
   "dependencies": {
+    "chalk": "^0.5.1",
     "grunt": "^0.4.5",
     "html-minifier": "^0.6.0"
   },

--- a/tasks/templatecache.js
+++ b/tasks/templatecache.js
@@ -8,6 +8,7 @@ var finalTemplate =
   '}]);\n';
 
 module.exports = function(grunt) {
+  var chalk = require('chalk');
 
   grunt.registerMultiTask('angularTemplateCache', function() {
     var options = this.options({
@@ -69,8 +70,10 @@ module.exports = function(grunt) {
     }
 
 
+    var templateCount = 0;
     this.files.forEach(function(files) {
       var cache = {};
+      templateCount += files.src.length;
       files.src.filter(function(f) {
         grunt.log.verbose.writeln('Found template: ' + f);
         var content = grunt.file.read(files.cwd + '/' + f);
@@ -99,6 +102,10 @@ module.exports = function(grunt) {
         }
       });
       grunt.file.write(files.dest, parsedTemplate);
+      grunt.log.writeln(
+        'Found ' + chalk.cyan(templateCount) + ' ' +
+        grunt.util.pluralize(templateCount, 'template/templates')
+      );
     });
   });
 };


### PR DESCRIPTION
This is a small change that tries to align the output of this plugin with standard plugins such as grunt-contrib-copy. Those plugins have less verbose output by default and will output a single summary line at the end saying how many files were processed.
