### PR TITLE
Added a fix to supporting window line break (CRLF)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,11 @@ module.exports = function(grunt) {
         src: 'index.html',
         dest: 'tmp/tabs.js',
         cwd: 'test/fixtures'
+      },
+      crlf: {
+        src: 'multiline_crlf.html',
+        dest: 'tmp/multiline_crlf.js',
+        cwd: 'test/fixtures'
       }
     },
     clean: {

--- a/tasks/templatecache.js
+++ b/tasks/templatecache.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
      */
     function q(string) {
       var quote = options.quote;
-      string = string.replace(/\\/, '\\\\').replace(/\r?\n/, '\\n');
+      string = string.replace(/\\/, '\\\\').replace(/\n/, '\\n');
       string = string.replace(new RegExp(quote, 'g'), '\\' + quote);
       return quote + string + quote;
     }
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
         } else {
           // Otherwise enquote each line and indent it nicely.
           var ending = '\n' + indent + indent;
-          tmpl = ending + tmpl.split(/^/gm).map(q).join(' +' + ending) +
+          tmpl = ending + tmpl.replace(/\r\n/g, '\n').split(/^/gm).map(q).join(' +' + ending) +
                  '\n' + indent;
         }
         out += '\n' + indent + grunt.template.process(

--- a/test/expected/multiline_crlf.js
+++ b/test/expected/multiline_crlf.js
@@ -2,15 +2,6 @@
 
 angular.module('hello.world').
 run(['$templateCache', function($templateCache) {
-  $templateCache.put('index.html', '<html></html>');
-  $templateCache.put('multiline.html',
-    '<html>\n' +
-    '  <head></head>\n' +
-    '  <body>\n' +
-    '    <h1>Hello world!</h1>\n' +
-    '  </body>\n' +
-    '</html>'
-  );
   $templateCache.put('multiline_crlf.html',
     '<html>\n' +
     '  <head></head>\n' +

--- a/test/fixtures/multiline_crlf.html
+++ b/test/fixtures/multiline_crlf.html
@@ -1,0 +1,6 @@
+<html>
+  <head></head>
+  <body>
+    <h1>Hello world!</h1>
+  </body>
+</html>


### PR DESCRIPTION
This PR is to fix the same problem mentioned in #3 . In the latest version I am still getting extra line breaks in the generated file when the source html has CRLF line breaks (files created in windows).

I've added a multiline_crlf.html file which contains CRLF line breaks to cover this test scenario.

Thanks!
